### PR TITLE
fixed variable name for `improper_feed` test

### DIFF
--- a/bap.tests/improper_feed.exp
+++ b/bap.tests/improper_feed.exp
@@ -16,8 +16,8 @@ set files {
 foreach {expected data} $files {
     set file [touch $data]
     spawn bap $file -d
-    set exit_status [lindex [wait] 3]    
-    if {$exit_status != 0} {
+    set status [lindex [wait] 3]    
+    if {$status != 0} {
         expect {
             $expected {pass "$test for $expected"}
             default {fail "no diagnostic messages in $test for $file"}


### PR DESCRIPTION
since using of `exit_status` name led to problem with
error with wrong exit status at the end of tests